### PR TITLE
Making androidScaleType work in Android

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Basics:
 | minimumZoomScale | float | The minimum allowed zoom scale. The default value is 1.0 |
 | maximumZoomScale | float | The maximum allowed zoom scale. The default value is 3.0 |
 | androidZoomTransitionDuration | int | **Android only**: Double-tap zoom transition duration |
-| androidScaleType | String | **Android only**: One of the default *Android* scale types: "center", "centerCrop", "centerInside", "fitCenter", "fitStart", "fitEnd", "fitXY", or "matrix" |
+| androidScaleType | String | **Android only**: One of the default *Android* scale types: "center", "centerCrop", "centerInside", "fitCenter", "fitStart", "fitEnd", "fitXY" |
 | onLoadStart | func | Callback function |
 | onLoad | func | Callback function |
 | onLoadEnd | func | Callback function |

--- a/android/src/main/java/com/reactnative/photoview/PhotoViewManager.java
+++ b/android/src/main/java/com/reactnative/photoview/PhotoViewManager.java
@@ -3,6 +3,8 @@ package com.reactnative.photoview;
 import android.widget.ImageView.ScaleType;
 import com.facebook.drawee.backends.pipeline.Fresco;
 import com.facebook.drawee.backends.pipeline.PipelineDraweeControllerBuilder;
+import com.facebook.drawee.drawable.ScalingUtils;
+import com.facebook.drawee.generic.GenericDraweeHierarchy;
 import com.facebook.react.bridge.ReactApplicationContext;
 import com.facebook.react.common.MapBuilder;
 import com.facebook.react.uimanager.SimpleViewManager;
@@ -72,35 +74,33 @@ public class PhotoViewManager extends SimpleViewManager<PhotoView> {
 
     @ReactProp(name = "androidScaleType")
     public void setScaleType(PhotoView view, String scaleType) {
-        ScaleType value = ScaleType.CENTER;
+        ScalingUtils.ScaleType value = ScalingUtils.ScaleType.CENTER;
 
         switch (scaleType) {
             case "center":
-                value = ScaleType.CENTER;
+                value = ScalingUtils.ScaleType.CENTER;
                 break;
             case "centerCrop":
-                value = ScaleType.CENTER_CROP;
+                value = ScalingUtils.ScaleType.CENTER_CROP;
                 break;
             case "centerInside":
-                value = ScaleType.CENTER_INSIDE;
+                value = ScalingUtils.ScaleType.CENTER_INSIDE;
                 break;
             case "fitCenter":
-                value = ScaleType.FIT_CENTER;
+                value = ScalingUtils.ScaleType.FIT_CENTER;
                 break;
             case "fitStart":
-                value = ScaleType.FIT_START;
+                value = ScalingUtils.ScaleType.FIT_START;
                 break;
             case "fitEnd":
-                value = ScaleType.FIT_END;
+                value = ScalingUtils.ScaleType.FIT_END;
                 break;
             case "fitXY":
-                value = ScaleType.FIT_XY;
-                break;
-            case "matrix":
-                value = ScaleType.MATRIX;
+                value = ScalingUtils.ScaleType.FIT_XY;
                 break;
         }
-        view.setScaleType(value);
+        GenericDraweeHierarchy hierarchy = view.getHierarchy();
+        hierarchy.setActualImageScaleType(value);
     }
 
     @Override


### PR DESCRIPTION
Hi Alexander,

First, thanks for releasing react-native-photo-view.

Today, I was trying your library for a project and found out `androidScaleType` is not working at all.

You can read the reasons in my commit and <a href="https://github.com/facebook/fresco/blob/master/drawee/src/main/java/com/facebook/drawee/view/DraweeView.java#L38-L43">here</a> and <a href="http://frescolib.org/docs/scaling.html">there</a>

Now, it works great. Except in one case that I've noticed. When you set `centerCrop`, panning is white:

<img src="http://g.recordit.co/FdPrV6lnuj.gif" />

I would expect the rest of the image, to appear when panning. Not sure what might be triggering this behavior.

Thanks, cheers
Miguel