### PR TITLE
Adds the showsHorizontalScrollIndicator & showsVerticalScrollIndicator as optional props for iOS

### DIFF
--- a/PhotoView.ios.js
+++ b/PhotoView.ios.js
@@ -14,8 +14,8 @@ export default class PhotoView extends Component {
                 centerContent={true}
                 maximumZoomScale={this.props.maximumZoomScale}
                 minimumZoomScale={this.props.minimumZoomScale} 
-                showsHorizontalScrollIndicator={this.props.showsHorizontalScrollIndicator || true} 
-                showsVerticalScrollIndicator={this.props.showsVerticalScrollIndicator || true} 
+                showsHorizontalScrollIndicator={this.props.showsHorizontalScrollIndicator} 
+                showsVerticalScrollIndicator={this.props.showsVerticalScrollIndicator} 
                 >
 
                 <TouchableWithoutFeedback

--- a/PhotoView.ios.js
+++ b/PhotoView.ios.js
@@ -13,7 +13,10 @@ export default class PhotoView extends Component {
                 contentContainerStyle={{ alignItems:'center', justifyContent:'center' }}
                 centerContent={true}
                 maximumZoomScale={this.props.maximumZoomScale}
-                minimumZoomScale={this.props.minimumZoomScale}>
+                minimumZoomScale={this.props.minimumZoomScale} 
+                showsHorizontalScrollIndicator={this.props.showsHorizontalScrollIndicator} 
+                showsVerticalScrollIndicator={this.props.showsVerticalScrollIndicator} 
+                >
 
                 <TouchableWithoutFeedback
                     onPress={this.props.onTap ? this.props.onTap : function() {}}>

--- a/PhotoView.ios.js
+++ b/PhotoView.ios.js
@@ -14,8 +14,8 @@ export default class PhotoView extends Component {
                 centerContent={true}
                 maximumZoomScale={this.props.maximumZoomScale}
                 minimumZoomScale={this.props.minimumZoomScale} 
-                showsHorizontalScrollIndicator={this.props.showsHorizontalScrollIndicator} 
-                showsVerticalScrollIndicator={this.props.showsVerticalScrollIndicator} 
+                showsHorizontalScrollIndicator={this.props.showsHorizontalScrollIndicator || true} 
+                showsVerticalScrollIndicator={this.props.showsVerticalScrollIndicator || true} 
                 >
 
                 <TouchableWithoutFeedback

--- a/README.md
+++ b/README.md
@@ -32,6 +32,8 @@ Basics:
 | fadeDuration | int | duration of image fade (in ms) |
 | minimumZoomScale | float | The minimum allowed zoom scale. The default value is 1.0 |
 | maximumZoomScale | float | The maximum allowed zoom scale. The default value is 3.0 |
+| showsHorizontalScrollIndicator | bool | **iOS only**: When true, shows a horizontal scroll indicator. The default value is true. |
+| showsVerticalScrollIndicator | bool | **iOS only**: When true, shows a vertical scroll indicator. The default value is true. |
 | scale | float | Set zoom scale programmatically |
 androidZoomTransitionDuration | int | **Android only**: Double-tap zoom transition duration |
 | androidScaleType | String | **Android only**: One of the default *Android* scale types: "center", "centerCrop", "centerInside", "fitCenter", "fitStart", "fitEnd", "fitXY" |


### PR DESCRIPTION
Hi,

this PR adds the ability to set showsHorizontalScrollIndicator & showsVerticalScrollIndicator props of the ScrollView for iOS. This PR does not change the defaults (which are `true`).
