### PR TITLE
Auto play GIF's and WebP's in Android

### DIFF
--- a/android/src/main/java/com/reactnative/photoview/PhotoView.java
+++ b/android/src/main/java/com/reactnative/photoview/PhotoView.java
@@ -141,6 +141,7 @@ public class PhotoView extends PhotoDraweeView {
 
         mDraweeControllerBuilder = builder;
         mDraweeControllerBuilder.setUri(mUri);
+        mDraweeControllerBuilder.setAutoPlayAnimations(true);
         mDraweeControllerBuilder.setOldController(getController());
         mDraweeControllerBuilder.setControllerListener(new BaseControllerListener<ImageInfo>() {
             @Override


### PR DESCRIPTION
React Native's Image is also using `setAutoPlayAnimations` to autoplay GIF's and WebP's. You still have to include the right fresco lib's as described on this page: https://facebook.github.io/react-native/docs/image.html#gif-and-webp-support-on-android