### PR TITLE
using ViewPropTypes instead of View.propTypes

### DIFF
--- a/PhotoView.android.js
+++ b/PhotoView.android.js
@@ -1,5 +1,6 @@
 import React, {Component, PropTypes} from 'react';
 import {requireNativeComponent, View} from 'react-native';
+import ViewPropTypes from 'react-native/Libraries/Components/View/ViewPropTypes';
 
 const resolveAssetSource = require('react-native/Libraries/Image/resolveAssetSource');
 
@@ -31,7 +32,7 @@ export default class PhotoView extends Component {
         onTap: PropTypes.func,
         onViewTap: PropTypes.func,
         onScale: PropTypes.func,
-        ...View.propTypes
+        ...ViewPropTypes
     };
 
     render() {


### PR DESCRIPTION
Using View.PropTypes is deprecated since 0.44.0.  facebook/react-native@53905a537a58d028fc5eb1c4e9a8ec967d8cd396
**This is a breaking change through**, it will require the latest react-native@0.44.0 installed.
