### PR TITLE
Fix for PropTypes being deprecated

### DIFF
--- a/PhotoView.android.js
+++ b/PhotoView.android.js
@@ -1,5 +1,6 @@
-import React, {Component, PropTypes} from 'react';
-import {requireNativeComponent, View} from 'react-native';
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
+import { requireNativeComponent, View } from 'react-native';
 import ViewPropTypes from 'react-native/Libraries/Components/View/ViewPropTypes';
 
 const resolveAssetSource = require('react-native/Libraries/Image/resolveAssetSource');
@@ -82,4 +83,5 @@ var cfg = {
         loadingIndicatorSrc: true
     }
 };
+
 const PhotoViewAndroid = requireNativeComponent('PhotoViewAndroid', PhotoView, cfg);

--- a/PhotoView.ios.js
+++ b/PhotoView.ios.js
@@ -1,4 +1,5 @@
-import React, { Component, PropTypes } from 'react';
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 import { requireNativeComponent, View } from 'react-native';
 import ViewPropTypes from 'react-native/Libraries/Components/View/ViewPropTypes';
 
@@ -80,4 +81,5 @@ var cfg = {
         loadingIndicatorSrc: true
     }
 };
+
 const RNPhotoView = requireNativeComponent('RNPhotoView', PhotoView, cfg);

--- a/package.json
+++ b/package.json
@@ -26,5 +26,8 @@
   "repository": {
     "type": "git",
     "url": "git://github.com/alwx/react-native-photo-view.git"
+  },
+  "dependencies": {
+    "prop-types": "^15.5.10"
   }
 }


### PR DESCRIPTION
Importing PropTypes from the "react" module was deprecated in react 15.5. This fixes that.