### PR TITLE
Fixing change in RCTImageFromLocalAssetURL behavior.

### DIFF
--- a/ios/RNPhotoView.m
+++ b/ios/RNPhotoView.m
@@ -295,10 +295,22 @@
         }
         _source = source;
         NSURL *imageURL = [NSURL URLWithString:uri];
-        UIImage *image = RCTImageFromLocalAssetURL(imageURL);
-        if (image) { // if local image
-            [self setImage:image];
-            return;
+
+        @try {
+            UIImage *image = RCTImageFromLocalAssetURL(imageURL);
+            if (image) { // if local image
+                [self setImage:image];
+                if (_onPhotoViewerLoad) {
+                    _onPhotoViewerLoad(nil);
+                }
+                if (_onPhotoViewerLoadEnd) {
+                    _onPhotoViewerLoadEnd(nil);
+                }
+                return;
+            }
+        }
+        @catch (NSException *exception) {
+            NSLog(@"%@", exception.reason);
         }
 
         NSURLRequest *request = [[NSURLRequest alloc] initWithURL:imageURL];


### PR DESCRIPTION
This change add onLoad and onLoadEnd for RCTImageFromLocalAssetURL image load.

In the most recent version of RN 0.50.x, it changed the RCTImageFromLocalAssetURL behavior. And then, now RCTImageFromLocalAssetURL also loads images from the web. So, react-native-photo-view is never calling the `onLoad` and `onLoadEnd` events.

I also opened a issue in RN repository to ask if this is intentional or a bug. facebook/react-native#16800