### PR TITLE
Update build.gradle

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -29,8 +29,12 @@ android {
 }
 
 repositories {
-    mavenCentral()
+    mavenLocal()
     jcenter()
+    maven {
+        // All of React Native (JS, Obj-C sources, Android binaries) is installed from npm
+        url "$projectDir/../../../node_modules/react-native/android"
+    }
 }
 
 dependencies {


### PR DESCRIPTION
After integrating this library with native-navigation of bamlab -https://github.com/bamlab/native-navigation, on android platform, i got the underlying error

```react-native-interactable\android\src\main\java\com\wix\interactable\Events.java:84: error: no suitable constructor found for Event(int)
            super(viewTag);
            ^
    constructor Event.Event() is not applicable
      (actual and formal argument lists differ in length)
    constructor Event.Event(int,long) is not applicable
      (actual and formal argument lists differ in length)```

I fixed it by making the some config changes in build.gradle & it's working now.
