### PR TITLE
iOS: Fix special character issue in image URL.

### DIFF
--- a/ios/RNPhotoView.m
+++ b/ios/RNPhotoView.m
@@ -294,7 +294,7 @@
             return;
         }
         _source = source;
-        NSURL *imageURL = [NSURL URLWithString:uri];
+        NSURL *imageURL = [NSURL URLWithString:[uri stringByAddingPercentEscapesUsingEncoding: NSUTF8StringEncoding]];
         
         if (![[uri substringToIndex:4] isEqualToString:@"http"]) {
             @try {


### PR DESCRIPTION
If the external URL contains special characters such as 你好 and مرحبا,
image could not be displayed. We have faced this issue in https://github.com/zulip/zulip-mobile/issues/2113. 

To resolve this,
we need to escape special characters in `uri` using UTF-8 encoding.

Fixes #129