### PR TITLE
Load network image in background queue

### DIFF
--- a/ios/RNPhotoView.m
+++ b/ios/RNPhotoView.m
@@ -285,7 +285,7 @@
 #pragma mark - Setter
 
 - (void)setSource:(NSDictionary *)source {
-    dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(0.1 * NSEC_PER_SEC)), dispatch_get_main_queue(), ^{
+    dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_HIGH, 0ul), ^{
         if ([_source isEqualToDictionary:source]) {
             return;
         }
@@ -300,7 +300,10 @@
             @try {
                 UIImage *image = RCTImageFromLocalAssetURL(imageURL);
                 if (image) { // if local image
-                    [self setImage:image];
+                    __weak RNPhotoView *weakSelf = self;
+                    dispatch_async(dispatch_get_main_queue(), ^{
+                        [weakSelf setImage:image];
+                    });
                     if (_onPhotoViewerLoad) {
                         _onPhotoViewerLoad(nil);
                     }


### PR DESCRIPTION
The library loads images in main queue causes the sluggish UI in iOS. The bigger the image the longer the loading time. Load the images in background queue fixed the issue.