### PR TITLE
Android: Add support for dynamic buildTools/compileSdk/etc versions

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -14,13 +14,17 @@ buildscript {
 
 apply plugin: 'com.android.library'
 
+def safeExtGet(prop, fallback) {
+    rootProject.ext.has(prop) ? rootProject.ext.get(prop) : fallback
+}
+
 android {
-    compileSdkVersion 23
-    buildToolsVersion "25.0.0"
+    compileSdkVersion safeExtGet('compileSdkVersion', 26)
+    buildToolsVersion safeExtGet('buildToolsVersion', '26.0.3')
 
     defaultConfig {
-        minSdkVersion 16
-        targetSdkVersion 22
+        minSdkVersion safeExtGet('minSdkVersion', 16)
+        targetSdkVersion safeExtGet('targetSdkVersion', 26)
         versionCode 1
     }
     lintOptions {
@@ -34,7 +38,7 @@ repositories {
 }
 
 dependencies {
-    compile 'com.facebook.react:react-native:+'
-    compile 'com.facebook.fresco:fresco:0.11.0'
-    compile 'me.relex:photodraweeview:1.0.0'
+    implementation 'com.facebook.react:react-native:+'
+    implementation "com.facebook.fresco:fresco:${safeExtGet('frescoVersion', '0.11.0')}"
+    implementation 'me.relex:photodraweeview:1.0.0'
 }


### PR DESCRIPTION
The buildTools version can be obtained from `rootProject.ext` on react-native 0.56. This commit adds support for that and if the variables are not defined falls back to the versions expected by react-native (on 0.56).

This also adds a way of customizing the fresco library version used via `rootProject.ext.frescoVersion`.

inspired by: https://github.com/geektimecoil/react-native-onesignal/issues/442#issuecomment-377177886