### PR TITLE
Update build.gradle file for RN 0.56+ support

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -15,12 +15,12 @@ buildscript {
 apply plugin: 'com.android.library'
 
 android {
-    compileSdkVersion 23
-    buildToolsVersion "25.0.0"
+    compileSdkVersion 26
+    buildToolsVersion "26.0.3"
 
     defaultConfig {
         minSdkVersion 16
-        targetSdkVersion 22
+        targetSdkVersion 26
         versionCode 1
     }
     lintOptions {


### PR DESCRIPTION
Latest version of react native requires android apps to use SDK version 26. This pull request contains the bumped up SDK version numbers and tested working on android 7, 8 and 9.