### PR TITLE
Increase version 1.5.3

### DIFF
--- a/ios/RNPhotoView.m
+++ b/ios/RNPhotoView.m
@@ -295,10 +295,22 @@
         }
         _source = source;
         NSURL *imageURL = [NSURL URLWithString:uri];
-        UIImage *image = RCTImageFromLocalAssetURL(imageURL);
-        if (image) { // if local image
-            [self setImage:image];
-            return;
+
+        @try {
+            UIImage *image = RCTImageFromLocalAssetURL(imageURL);
+            if (image) { // if local image
+                [self setImage:image];
+                if (_onPhotoViewerLoad) {
+                    _onPhotoViewerLoad(nil);
+                }
+                if (_onPhotoViewerLoadEnd) {
+                    _onPhotoViewerLoadEnd(nil);
+                }
+                return;
+            }
+        }
+        @catch (NSException *exception) {
+            NSLog(@"%@", exception.reason);
         }
 
         NSURLRequest *request = [[NSURLRequest alloc] initWithURL:imageURL];

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-photo-view",
-  "version": "1.5.2",
+  "version": "1.5.3"
   "description": "Displaying photos with pinch-to-zoom",
   "main": "index.js",
   "author": {


### PR DESCRIPTION
# Summary:
- When I run "yarn install" to install react-native-photo-view version 1.5.2. It cannot download podspec file and cannot automatically linking in RN 0.60.x and Cocoapods. The root cause is we add or update on master but did not upgrade the version

# Solution:
- Increase version to 1.5.3 in order to support who wants to install react-native-photo-view and integrate to Cocoapods and RN 0.60.x
