### PR TITLE
chore(android): replaced jCenter with mavenCentral

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -3,7 +3,7 @@
 buildscript {
     repositories {
         google()
-        jcenter()
+        mavenCentral()
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:3.3.2'
@@ -29,7 +29,6 @@ android {
 repositories {
     mavenCentral()
     google()
-    jcenter()
 }
 
 dependencies {


### PR DESCRIPTION
# Overview
jCenter will be offline in February 2022. I've updated the android project to use maven.

# Test Plan
I've tested the library on a personal project and it builds without issues.